### PR TITLE
Add angle brackets around the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # DEPRECATED
 
 Please note that as Google Benchmark now has an official Conan support this repository should be considered
-deprecated. Please download the latest google benchmark from: https://bintray.com/conan/conan-center/benchmark%3A_.
+deprecated. Please download the latest google benchmark from: <https://bintray.com/conan/conan-center/benchmark%3A_>.
 
 ---
 


### PR DESCRIPTION
Without angle brackets, the URL isn't converted into a link in many markdown parsers.

Before:
https://bintray.com/conan/conan-center/benchmark%3A_

After:
<https://bintray.com/conan/conan-center/benchmark%3A_>

In first case last character doesn't included into URL.